### PR TITLE
feat: allow user to override commit title character limit setting

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,12 +9,14 @@ import (
 	"github.com/stefanlogue/meteor/pkg/config"
 )
 
+const defaultCommitTitleCharLimit = 48
+
 // loadConfig loads the config file from the current directory or any parent
-func loadConfig(fs afero.Fs) ([]huh.Option[string], []huh.Option[string], []huh.Option[string], bool, error) {
+func loadConfig(fs afero.Fs) ([]huh.Option[string], []huh.Option[string], []huh.Option[string], bool, int, error) {
 	filePath, err := config.FindConfigFile(fs)
 	if err != nil {
 		log.Debug("Error finding config file", "error", err)
-		return config.DefaultPrefixes, nil, nil, true, nil
+		return config.DefaultPrefixes, nil, nil, true, defaultCommitTitleCharLimit, nil
 	}
 
 	log.Debug("found config file", "path", filePath)
@@ -23,7 +25,7 @@ func loadConfig(fs afero.Fs) ([]huh.Option[string], []huh.Option[string], []huh.
 
 	err = c.LoadFile(filePath)
 	if err != nil {
-		return nil, nil, nil, true, fmt.Errorf("error parsing config file: %w", err)
+		return nil, nil, nil, true, defaultCommitTitleCharLimit, fmt.Errorf("error parsing config file: %w", err)
 	}
 
 	if c.ShowIntro == nil {
@@ -31,5 +33,10 @@ func loadConfig(fs afero.Fs) ([]huh.Option[string], []huh.Option[string], []huh.
 		c.ShowIntro = &showIntro
 	}
 
-	return c.Prefixes.Options(), c.Coauthors.Options(), c.Boards.Options(), *c.ShowIntro, nil
+	if c.CommitTitleCharLimit == nil || *c.CommitTitleCharLimit < defaultCommitTitleCharLimit {
+		commitTitleCharLimit := defaultCommitTitleCharLimit
+		c.CommitTitleCharLimit = &commitTitleCharLimit
+	}
+
+	return c.Prefixes.Options(), c.Coauthors.Options(), c.Boards.Options(), *c.ShowIntro, *c.CommitTitleCharLimit, nil
 }

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func main() {
 		fail("Could not change directory: %s", err)
 	}
 
-	prefixes, coauthors, boards, showIntro, err := loadConfig(AFS)
+	prefixes, coauthors, boards, showIntro, commitTitleCharLimit, err := loadConfig(AFS)
 	if err != nil {
 		fail("Error: %s", err)
 	}
@@ -216,7 +216,7 @@ func main() {
 			huh.NewInput().
 				Value(&newCommit.Message).
 				Title("Message").
-				CharLimit(48),
+				CharLimit(commitTitleCharLimit),
 			huh.NewText().
 				Value(&newCommit.Body).
 				Title("Body").

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,10 +10,11 @@ import (
 )
 
 type Config struct {
-	ShowIntro *bool     `json:"showIntro"`
-	Prefixes  Prefixes  `json:"prefixes"`
-	Coauthors CoAuthors `json:"coauthors"`
-	Boards    Boards    `json:"boards"`
+	ShowIntro            *bool     `json:"showIntro"`
+	Prefixes             Prefixes  `json:"prefixes"`
+	Coauthors            CoAuthors `json:"coauthors"`
+	Boards               Boards    `json:"boards"`
+	CommitTitleCharLimit *int      `json:"commitTitleCharLimit"`
 }
 
 // New returns a new Config


### PR DESCRIPTION
This pull request introduces a new configuration option to allow users to override the default commit title character limit of 48 characters. In our environment, the commit title character limit is not strictly enforced, and the default value of 48 was too restrictive.

Thank you for this excellent tool! It has been incredibly helpful.