### PR TITLE
Add "build" prefix

### DIFF
--- a/pkg/config/prefix.go
+++ b/pkg/config/prefix.go
@@ -25,6 +25,7 @@ var (
 		huh.NewOption("chore - changes to the build process or auxiliary tools and libraries", "chore"),
 		huh.NewOption("revert - reverts a previous commit", "revert"),
 		huh.NewOption("ci - changes to our CI configuration files and scripts", "ci"),
+		huh.NewOption("build - changes that affect the build system or external dependencies", "build"),
 	}
 )
 


### PR DESCRIPTION
I was surprised to not find the "build" prefix, was this an oversight or intentional?  
It is advised by both conventionalcommits.org and the Angular guide:
* https://www.conventionalcommits.org/en/v1.0.0/#summary
* https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type

Thanks, and great tool! I'm happy to switch from Commitizen to a Go alternative.