### PR TITLE
fix(commit format)!: change to commit order and fix for find

### DIFF
--- a/git.go
+++ b/git.go
@@ -49,8 +49,8 @@ func getGitTicketNumber(board string) string {
 		if err != nil {
 			return ""
 		}
-		re := regexp.MustCompile(`(.*):.*`)
-		ticket := re.ReplaceAllString(string(out), "$1")
+		re := regexp.MustCompile(`(.*):.*(<(.*)>)?.*`)
+		ticket := re.ReplaceAllString(string(out), "$3")
 		return strings.TrimSpace(ticket)
 	}
 

--- a/main.go
+++ b/main.go
@@ -186,15 +186,15 @@ func main() {
 	if len(newCommit.Board) > 0 && newCommit.Board != "NONE" {
 		if newCommit.IsBreakingChange {
 			if len(newCommit.Scope) > 0 {
-				newCommit.Message = fmt.Sprintf("%s(%s)!: <%s> ", newCommit.TicketNumber, newCommit.Scope, newCommit.Type)
+				newCommit.Message = fmt.Sprintf("%s(%s)!: <%s> ", newCommit.Type, newCommit.Scope, newCommit.TicketNumber)
 			} else {
-				newCommit.Message = fmt.Sprintf("%s!: <%s> ", newCommit.TicketNumber, newCommit.Type)
+				newCommit.Message = fmt.Sprintf("%s!: <%s> ",  newCommit.Type, newCommit.TicketNumber)
 			}
 		} else {
 			if len(newCommit.Scope) > 0 {
-				newCommit.Message = fmt.Sprintf("%s(%s): <%s> ", newCommit.TicketNumber, newCommit.Scope, newCommit.Type)
+				newCommit.Message = fmt.Sprintf("%s(%s): <%s> ", newCommit.Type, newCommit.Scope, newCommit.TicketNumber)
 			} else {
-				newCommit.Message = fmt.Sprintf("%s: <%s> ", newCommit.TicketNumber, newCommit.Type)
+				newCommit.Message = fmt.Sprintf("%s: <%s> ", newCommit.Type, newCommit.TicketNumber)
 			}
 		}
 	} else {

--- a/main.go
+++ b/main.go
@@ -188,7 +188,7 @@ func main() {
 			if len(newCommit.Scope) > 0 {
 				newCommit.Message = fmt.Sprintf("%s(%s)!: <%s> ", newCommit.Type, newCommit.Scope, newCommit.TicketNumber)
 			} else {
-				newCommit.Message = fmt.Sprintf("%s!: <%s> ",  newCommit.Type, newCommit.TicketNumber)
+				newCommit.Message = fmt.Sprintf("%s!: <%s> ", newCommit.Type, newCommit.TicketNumber)
 			}
 		} else {
 			if len(newCommit.Scope) > 0 {

--- a/pkg/config/find.go
+++ b/pkg/config/find.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-
+	"strings"
 	"github.com/charmbracelet/log"
 	"github.com/spf13/afero"
 )
@@ -27,24 +27,27 @@ func FindConfigFile(fs afero.Fs) (string, error) {
 	}
 
 	homeDir, err := os.UserHomeDir()
+	log.Debug("Home directoy: ", "homeDir", homeDir)
 	if err != nil {
 		return "", fmt.Errorf("error getting home dir: %w", err)
 	}
 
 	currentDir, err := os.Getwd()
+	log.Debug("Current directory: ", "currentDir", currentDir)
 	if err != nil {
 		return "", fmt.Errorf("error getting current dir: %w", err)
 	}
 
 	for {
 		rel, _ := filepath.Rel(homeDir, currentDir)
-		if rel == ".." {
+		if strings.Trim(rel,"../") == "" {
 			break
 		}
+		log.Debug("relative path: ", "rel", rel)
 
 		filePath := filepath.Join(currentDir, configFile)
 		log.Debug("checking for config file", "path", filePath)
-
+		
 		if _, err := fs.Open(filePath); err == nil {
 			return filePath, nil
 		}


### PR DESCRIPTION
Change to commit order so that type, scope, and ticket number always appear in the same order.

[BREAKING CHANGE] As this is a change to the commit ordering, this may effect consumers of this repos handling in pipelines or other integrations.

fix to finder function to handle when relative resolves to "../.." or "../", by trimming string of these characters