### PR TITLE
feat(config): skipping breaking change dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- config option for skipping breaking change dialog
 ### Fixed
 - Workflow now targets tags correctly again
 

--- a/README.md
+++ b/README.md
@@ -120,3 +120,13 @@ your config:
   "showIntro": false
 }
 ```
+
+### Breaking Change
+
+If you want to skip the breaking change dialog, add the following to your config:
+
+```json
+{
+  "askBreakingChange": false
+}
+```

--- a/config.go
+++ b/config.go
@@ -24,6 +24,7 @@ type LoadConfigReturn struct {
 	Scopes                    []huh.Option[string]
 	CommitTitleCharLimit      int
 	ShowIntro                 bool
+	AskBreakingChange         bool
 }
 
 // loadConfig loads the config file from the current directory or any parent
@@ -37,6 +38,7 @@ func loadConfig(fs afero.Fs) (LoadConfigReturn, error) {
 			Prefixes:                  config.DefaultPrefixes,
 			CommitTitleCharLimit:      defaultCommitTitleCharLimit,
 			ShowIntro:                 true,
+			AskBreakingChange:         true,
 		}, nil
 	}
 
@@ -51,12 +53,18 @@ func loadConfig(fs afero.Fs) (LoadConfigReturn, error) {
 			MessageWithTicketTemplate: defaultMessageWithTicketTemplate,
 			CommitTitleCharLimit:      defaultCommitTitleCharLimit,
 			ShowIntro:                 true,
+			AskBreakingChange:         true,
 		}, fmt.Errorf("error parsing config file: %w", err)
 	}
 
 	if c.ShowIntro == nil {
 		showIntro := true
 		c.ShowIntro = &showIntro
+	}
+
+	if c.AskBreakingChange == nil {
+		askBreakingChange := true
+		c.AskBreakingChange = &askBreakingChange
 	}
 
 	if c.CommitTitleCharLimit == nil || *c.CommitTitleCharLimit < defaultCommitTitleCharLimit {
@@ -93,5 +101,6 @@ func loadConfig(fs afero.Fs) (LoadConfigReturn, error) {
 		Scopes:                    c.Scopes.Options(),
 		CommitTitleCharLimit:      *c.CommitTitleCharLimit,
 		ShowIntro:                 *c.ShowIntro,
+		AskBreakingChange:         *c.AskBreakingChange,
 	}, nil
 }

--- a/main.go
+++ b/main.go
@@ -155,6 +155,12 @@ func main() {
 		}
 	}
 
+	typeInput := huh.NewSelect[string]().
+		Title("Type").
+		Description("Select the type of change that you're committing").
+		Options(config.Prefixes...).
+		Value(&newCommit.Type)
+
 	// if the user has specified scopes in their config, use a select input, otherwise use a text input
 	var scopeInput huh.Field
 	if len(config.Scopes) > 0 {
@@ -171,13 +177,11 @@ func main() {
 			Value(&newCommit.Scope)
 	}
 
-	mainForm := huh.NewForm(
-		huh.NewGroup(
-			huh.NewSelect[string]().
-				Title("Type").
-				Description("Select the type of change that you're committing").
-				Options(config.Prefixes...).
-				Value(&newCommit.Type),
+	// if the user has specified for asking breaking change, add a confirm input to the main group
+	var mainGroup *huh.Group
+	if config.AskBreakingChange {
+		mainGroup = huh.NewGroup(
+			typeInput,
 			huh.NewConfirm().
 				Title("Breaking Change").
 				Description("Is this a breaking change?").
@@ -185,7 +189,13 @@ func main() {
 				Negative("Nope.").
 				Value(&newCommit.IsBreakingChange),
 			scopeInput,
-		),
+		)
+	} else {
+		mainGroup = huh.NewGroup(typeInput, scopeInput)
+	}
+
+	mainForm := huh.NewForm(
+		mainGroup,
 		huh.NewGroup(
 			huh.NewMultiSelect[string]().
 				Title("Coauthors").

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	Coauthors                 CoAuthors `json:"coauthors"`
 	Boards                    Boards    `json:"boards"`
 	Scopes                    Scopes    `json:"scopes"`
+	AskBreakingChange         *bool     `json:"askBreakingChange"`
 }
 
 // New returns a new Config


### PR DESCRIPTION
## Changes

This PR adds a config option to allow users to skip the breaking change dialog.
This change doesn't produce any breaking changes.

Closes #51