### PR TITLE
feat(flag): Add an ability to skip breaking change dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- flag for skipping breaking change prompt
 ### Fixed
 - Workflow now targets tags correctly again
 


### PR DESCRIPTION
## Changes

This PR adds a flag to allow users to skip the breaking change prompt.
This change doesn't produce any breaking changes.

Closes #51
Related #52