### PR TITLE
Update installation steps for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,12 @@ supported in `git commit` will still work.
 
 ```console
 brew tap stefanlogue/tools
-brew install meteor
+brew install --cask meteor
 ```
+
+> [!IMPORTANT]
+> If you previously installed `meteor` from the formula, you'll need to
+> uninstall it before installing it from the cask
 
 ### Go
 


### PR DESCRIPTION
## Description

Recent changes in `goreleaser` have resulted in `meteor` needing to be installed from a cask rather than a formula. This PR updates the installation steps in the readme to reflect these changes