### PR TITLE
Fix infinite loop when working directory is outside of `home` tree

### DIFF
--- a/pkg/config/find.go
+++ b/pkg/config/find.go
@@ -34,7 +34,7 @@ func FindConfigFile(fs afero.Fs, getWD func() (string, error), getHome func() (s
 		return "", fmt.Errorf("error getting current dir: %w", err)
 	}
 
-	for {
+	for currentDir != "/" {
 		rel, _ := filepath.Rel(homeDir, currentDir)
 		if rel == ".." {
 			break

--- a/pkg/config/find_test.go
+++ b/pkg/config/find_test.go
@@ -69,6 +69,22 @@ func TestFindConfigFile(t *testing.T) {
 		assertEqual(t, expected, got)
 		assertIsNotError(t, err)
 	})
+	t.Run("WD not in home directory", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		currentDir := "/var/www/hosts/project"
+		configPath := filepath.Join(homeDir, ".config/meteor/config.json")
+		fs.MkdirAll(filepath.Dir(configPath), 0755)
+		content := "{}"
+		writeErr := afero.WriteFile(fs, configPath, []byte(content), 0644)
+		assertIsNotError(t, writeErr)
+		expected := configPath
+		got, err := FindConfigFile(fs,
+			func() (string, error) { return currentDir, nil },
+			func() (string, error) { return homeDir, nil },
+		)
+		assertEqual(t, expected, got)
+		assertIsNotError(t, err)
+	})
 	t.Run("config file in xdg config dir", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
 		currentDir := "/home/user/project"

--- a/pkg/config/find_test.go
+++ b/pkg/config/find_test.go
@@ -69,9 +69,9 @@ func TestFindConfigFile(t *testing.T) {
 		assertEqual(t, expected, got)
 		assertIsNotError(t, err)
 	})
-	t.Run("WD not in home directory", func(t *testing.T) {
+	t.Run("config file in xdg config dir", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
-		currentDir := "/var/www/hosts/project"
+		currentDir := "/home/user/project"
 		configPath := filepath.Join(homeDir, ".config/meteor/config.json")
 		fs.MkdirAll(filepath.Dir(configPath), 0755)
 		content := "{}"
@@ -85,9 +85,9 @@ func TestFindConfigFile(t *testing.T) {
 		assertEqual(t, expected, got)
 		assertIsNotError(t, err)
 	})
-	t.Run("config file in xdg config dir", func(t *testing.T) {
+	t.Run("WD not in home directory", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
-		currentDir := "/home/user/project"
+		currentDir := "/var/www/hosts/project"
 		configPath := filepath.Join(homeDir, ".config/meteor/config.json")
 		fs.MkdirAll(filepath.Dir(configPath), 0755)
 		content := "{}"


### PR DESCRIPTION
## Description

This PR introduces a fix for a bug where the `FindConfigFile` function would go into an infinite loop if the working directory was not under the `home` directory tree, e.g. `/var/www/hosts/project/`. In this case, the function would recurse upwards until it reached `/` and continue to check for the config file infinitely.

I've added an explicit condition to the loop which covers this case and I think will cover all other cases, I can't think of a case where the current directory would be an empty string (if one exists please let me know).

Closes #77 