### PR TITLE
Add ability to select multiple scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ you can provide your own! The syntax can be seen in the defaults below:
 
 - `@type`: the conventional commit type i.e. `feat`, `chore` etc.
 - `@message`: the commit message
-- `(@scope)`: (optional but recommended) the scope of the commit, must be within
+- `(@scope)`: (optional but recommended) the scope(s) of the commit, must be within
 parentheses
 
 `messageWithTicketTemplate` also additionally takes `@ticket`

--- a/config.go
+++ b/config.go
@@ -15,8 +15,8 @@ const (
 	defaultCommitBodyCharLimit       = 0
 	defaultCommitBodyLineLength      = 0
 	minimumCommitBodyLineLength      = 20
-	defaultMessageTemplate           = "{{.Type}}{{if .Scope}}({{.Scope}}){{end}}{{if .IsBreakingChange}}!{{end}}: {{.Message}}"
-	defaultMessageWithTicketTemplate = "{{.TicketNumber}}{{if .Scope}}({{.Scope}}){{end}}{{if .IsBreakingChange}}!{{end}}: <{{.Type}}> {{.Message}}"
+	defaultMessageTemplate           = "{{.Type}}{{if .Scopes}}({{.ScopeValue}}){{end}}{{if .IsBreakingChange}}!{{end}}: {{.Message}}"
+	defaultMessageWithTicketTemplate = "{{.TicketNumber}}{{if .Scopes}}({{.ScopeValue}}){{end}}{{if .IsBreakingChange}}!{{end}}: <{{.Type}}> {{.Message}}"
 )
 
 type LoadConfigReturn struct {

--- a/pkg/config/messageTemplate.go
+++ b/pkg/config/messageTemplate.go
@@ -14,7 +14,11 @@ func ConvertTemplate(t string) (string, error) {
 	}
 	t = strings.Replace(t, ":", "{{if .IsBreakingChange}}!{{end}}:", 1)
 	t = strings.ReplaceAll(t, "@type", "{{.Type}}")
-	t = strings.ReplaceAll(t, "(@scope)", "{{if .Scope}}({{.Scope}}){{end}}")
+	t = strings.ReplaceAll(
+		t,
+		"(@scope)",
+		"{{if .Scopes}}{{printf \"(%s)\" .ScopeValue}}{{end}}",
+	)
 	t = strings.ReplaceAll(t, "@ticket", "{{.TicketNumber}}")
 	t = strings.ReplaceAll(t, "@message", "{{.Message}}")
 	return t, nil

--- a/pkg/config/messageTemplate_test.go
+++ b/pkg/config/messageTemplate_test.go
@@ -8,9 +8,21 @@ func TestConvertTemplate(t *testing.T) {
 		input string
 		want  string
 	}{
-		{"adds breaking change marker", "@type: @message", "{{.Type}}{{if .IsBreakingChange}}!{{end}}: {{.Message}}"},
-		{"converts template", "@type(@scope): @message", "{{.Type}}{{if .Scope}}({{.Scope}}){{end}}{{if .IsBreakingChange}}!{{end}}: {{.Message}}"},
-		{"converts without scope", "@type: @message", "{{.Type}}{{if .IsBreakingChange}}!{{end}}: {{.Message}}"},
+		{
+			"adds breaking change marker",
+			"@type: @message",
+			"{{.Type}}{{if .IsBreakingChange}}!{{end}}: {{.Message}}",
+		},
+		{
+			"converts template",
+			"@type(@scope): @message",
+			"{{.Type}}{{if .Scopes}}{{printf \"(%s)\" .ScopeValue}}{{end}}{{if .IsBreakingChange}}!{{end}}: {{.Message}}",
+		},
+		{
+			"converts without scope",
+			"@type: @message",
+			"{{.Type}}{{if .IsBreakingChange}}!{{end}}: {{.Message}}",
+		},
 	}
 	for _, tc := range validCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Heyhey c:
First of all, thanks for the tool! It's really handy, because due to my attention deficit, I always have the worst time writing consistent semantic commit messages.

Recently I've noticed that after some real use in a service, I usually touch many scopes within one commit. I've added support for that here using `huh.MultiSelect` instead of regular `huh.Select`.

Thanks for considering this change, please let me know if I can fix/improve anything. Thanks again <3