### PR TITLE
Allow custom scopes and prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ The content should be in the following format:
   "commitTitleCharLimit": 60,
   "commitBodyCharLimit": 60,
   "commitBodyLineLength": 40,
-  "readContributorsFromGit": true
+  "readContributorsFromGit": true,
+  "allowCustomPrefixes": true
 }
 ```
 
@@ -92,7 +93,8 @@ If you want to define a set of predefined scopes to select from rather than
 typing the scope, a `scopes` array can be added to your config:
 
 > [!WARNING]
-> Setting predefined scopes removes the ability to type the scope
+> Setting predefined scopes removes the ability to type the scope, unless
+> `allowCustomScopes` is set to `true` in your config file
 
 ```json
 {

--- a/config.go
+++ b/config.go
@@ -23,15 +23,19 @@ const (
 type LoadConfigReturn struct {
 	MessageTemplate           string
 	MessageWithTicketTemplate string
-	Prefixes                  []huh.Option[string]
+	SelectablePrefixes        []huh.Option[string]
+	Prefixes                  []string
 	Coauthors                 []huh.Option[string]
 	Boards                    []huh.Option[string]
 	Scopes                    []huh.Option[string]
+	ScopeStrings              []string
 	CommitTitleCharLimit      int
 	CommitBodyCharLimit       int
 	CommitBodyLineLength      int
 	ShowIntro                 bool
 	ReadContributorsFromGit   bool
+	AllowCustomPrefixes       bool
+	AllowCustomScopes         bool
 }
 
 // loadConfig loads the config file from the current directory or any parent
@@ -42,12 +46,14 @@ func loadConfig(fs afero.Fs) (LoadConfigReturn, error) {
 		return LoadConfigReturn{
 			MessageTemplate:           defaultMessageTemplate,
 			MessageWithTicketTemplate: defaultMessageWithTicketTemplate,
+			SelectablePrefixes:        config.DefaultSelectablePrefixes,
 			Prefixes:                  config.DefaultPrefixes,
 			CommitTitleCharLimit:      defaultCommitTitleCharLimit,
 			CommitBodyCharLimit:       defaultCommitBodyCharLimit,
 			CommitBodyLineLength:      defaultCommitBodyLineLength,
 			ShowIntro:                 true,
 			ReadContributorsFromGit:   false,
+			AllowCustomPrefixes:       false,
 		}, nil
 	}
 
@@ -65,6 +71,7 @@ func loadConfig(fs afero.Fs) (LoadConfigReturn, error) {
 			CommitBodyLineLength:      defaultCommitBodyLineLength,
 			ShowIntro:                 true,
 			ReadContributorsFromGit:   false,
+			AllowCustomPrefixes:       false,
 		}, fmt.Errorf("error parsing config file: %w", err)
 	}
 
@@ -93,6 +100,16 @@ func loadConfig(fs afero.Fs) (LoadConfigReturn, error) {
 		c.ReadContributorsFromGit = &read
 	}
 
+	if c.AllowCustomPrefixes == nil {
+		allowCustomPrefixes := false
+		c.AllowCustomPrefixes = &allowCustomPrefixes
+	}
+
+	if c.AllowCustomScopes == nil {
+		allowCustomScopes := false
+		c.AllowCustomScopes = &allowCustomScopes
+	}
+
 	messageTemplate := defaultMessageTemplate
 	if c.MessageTemplate != nil {
 		messageTemplate, err = config.ConvertTemplate(*c.MessageTemplate)
@@ -116,14 +133,18 @@ func loadConfig(fs afero.Fs) (LoadConfigReturn, error) {
 	return LoadConfigReturn{
 		MessageTemplate:           messageTemplate,
 		MessageWithTicketTemplate: messageWithTicketTemplate,
-		Prefixes:                  c.Prefixes.Options(),
+		SelectablePrefixes:        c.Prefixes.Options(),
+		Prefixes:                  c.Prefixes.Strings(),
 		Coauthors:                 c.Coauthors.Options(),
 		Boards:                    c.Boards.Options(),
 		Scopes:                    c.Scopes.Options(),
+		ScopeStrings:              c.Scopes.Strings(),
 		CommitTitleCharLimit:      *c.CommitTitleCharLimit,
 		CommitBodyCharLimit:       *c.CommitBodyCharLimit,
 		CommitBodyLineLength:      *c.CommitBodyLineLength,
 		ShowIntro:                 *c.ShowIntro,
 		ReadContributorsFromGit:   *c.ReadContributorsFromGit,
+		AllowCustomPrefixes:       *c.AllowCustomPrefixes,
+		AllowCustomScopes:         *c.AllowCustomScopes,
 	}, nil
 }

--- a/internal/util/isFlagPassed.go
+++ b/internal/util/isFlagPassed.go
@@ -1,0 +1,13 @@
+package util
+
+import "flag"
+
+func IsFlagPassed(name string) bool {
+	found := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			found = true
+		}
+	})
+	return found
+}

--- a/internal/util/isFlagPassed_test.go
+++ b/internal/util/isFlagPassed_test.go
@@ -1,0 +1,34 @@
+package util_test
+
+import (
+	"testing"
+
+	"github.com/stefanlogue/meteor/internal/util"
+)
+
+func TestIsFlagPassed(t *testing.T) {
+	tests := []struct {
+		name     string
+		flagName string
+		want     bool
+	}{
+		{
+			name:     "version flag is passed",
+			flagName: "version",
+			want:     false, // Will be false in test context unless explicitly set
+		},
+		{
+			name:     "non-existent flag",
+			flagName: "non-existent-flag",
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := util.IsFlagPassed(tt.flagName)
+			if got != tt.want {
+				t.Errorf("IsFlagPassed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -159,15 +159,34 @@ func main() {
 		}
 	}
 
-	typeInput := huh.NewSelect[string]().
-		Title("Type").
-		Description("Select the type of change that you're committing").
-		Options(config.Prefixes...).
-		Value(&newCommit.Type)
+	var typeInput huh.Field
+	if config.AllowCustomPrefixes {
+		typeInput = huh.NewInput().
+			Title("Type").
+			Description("Select the type of change that you're committing").
+			CharLimit(16).
+			Suggestions(config.Prefixes).
+			Value(&newCommit.Type)
+	} else {
+		typeInput = huh.NewSelect[string]().
+			Title("Type").
+			Description("Select the type of change that you're committing").
+			Options(config.SelectablePrefixes...).
+			Value(&newCommit.Type)
+	}
 
-	// if the user has specified scopes in their config, use a select input, otherwise use a text input
+	// if the user has specified scopes in their config and allowCustomScopes is true, use a text input with suggestions
+	// if the user has specified scopes in their config and allowCustomScopes is false, use a select input
+	// otherwise use a text input
 	var scopeInput huh.Field
-	if len(config.Scopes) > 0 {
+	if config.AllowCustomScopes && len(config.ScopeStrings) > 0 {
+		scopeInput = huh.NewInput().
+			Title("Scope").
+			Description("Specify a scope of the changes").
+			CharLimit(16).
+			Suggestions(config.ScopeStrings).
+			Value(&newCommit.Scope)
+	} else if len(config.Scopes) > 0 {
 		scopeInput = huh.NewSelect[string]().
 			Title("Scope").
 			Description("Choose a scope for the changes").

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/fatih/color"
 	"github.com/stefanlogue/meteor/internal/util"
+	cfg "github.com/stefanlogue/meteor/pkg/config"
 
 	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/bubbles/key"
@@ -27,17 +28,6 @@ type Commit struct {
 	Body             string
 	Coauthors        []string
 	IsBreakingChange bool
-}
-
-// isFlagPassed checks if a flag has been passed
-func isFlagPassed(name string) bool {
-	found := false
-	flag.Visit(func(f *flag.Flag) {
-		if f.Name == name {
-			found = true
-		}
-	})
-	return found
 }
 
 var (
@@ -62,7 +52,7 @@ func init() {
 	flag.BoolVarP(&debugMode, "debug", "D", false, "enable debug mode")
 	flag.BoolVarP(&skipBreakingChange, "skip-breaking-change", "b", false, "skip breaking change prompt")
 	flag.Parse()
-	if isFlagPassed("version") {
+	if util.IsFlagPassed("version") {
 		fmt.Printf("meteor version %s\n", version)
 		os.Exit(0)
 	}
@@ -103,7 +93,7 @@ func main() {
 
 	var newCommit Commit
 	theme := huh.ThemeCatppuccin()
-	if config.ShowIntro && (isFlagPassed("skip-intro") && !skipIntro) {
+	if config.ShowIntro && (util.IsFlagPassed("skip-intro") && !skipIntro) {
 		introForm := huh.NewForm(
 			huh.NewGroup(
 				splashScreen(),
@@ -309,7 +299,7 @@ func main() {
 	}
 
 	if len(newCommit.Coauthors) > 0 {
-		newCommit.Body = newCommit.Body + buildCoauthorString(newCommit.Coauthors)
+		newCommit.Body = newCommit.Body + cfg.BuildCoAuthorString(newCommit.Coauthors)
 	}
 
 	args := flag.Args()
@@ -318,14 +308,14 @@ func main() {
 
 	// If we're operating in GIT_EDITOR="meteor --as-git-editor" mode, the first argument is the path (.git/COMMIT_EDITMSG)
 	// where we should write the git commit message, so we shift that from args before constructing the end-user command line
-	if isFlagPassed(AsGitEditor) {
+	if util.IsFlagPassed(AsGitEditor) {
 		commitFile = args[0]
 		args = args[1:]
 	}
 
 	rawCommitCommand, printableCommitCommand := buildCommitCommand(newCommit.Message, newCommit.Body, args)
 
-	if isFlagPassed(AsGitEditor) {
+	if util.IsFlagPassed(AsGitEditor) {
 		// We intent to do the commit
 		if doesWantToCommit {
 			// Write the commit message file (.git/COMMIT_EDITMSG) in same format as git would have,
@@ -389,23 +379,6 @@ func writeToClipboard(s string) {
 	if err := clipboard.WriteAll(s); err != nil {
 		fail("Failed to copy to clipboard: %s", err)
 	}
-}
-
-// buildCoauthorString takes a slice of selected coauthors and returns a formatted
-// string which Github recognises
-func buildCoauthorString(coauthors []string) string {
-	s := `
-
-
-	`
-
-	for _, coauthor := range coauthors {
-		if coauthor == "none" {
-			return ""
-		}
-		s += fmt.Sprintf("\nCo-authored-by: %s", coauthor)
-	}
-	return s
 }
 
 // splashScreen returns a note with a splash screen

--- a/pkg/config/co_author.go
+++ b/pkg/config/co_author.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/charmbracelet/huh"
 )
@@ -26,4 +27,22 @@ func (p *CoAuthors) Options() []huh.Option[string] {
 		items = append(items, huh.NewOption(desc, desc))
 	}
 	return items
+}
+
+// BuildCoauthorString takes a slice of selected coauthors and returns a formatted
+// string which Github recognises
+func BuildCoAuthorString(coauthors []string) string {
+	var s strings.Builder
+	s.WriteString(`
+
+
+	`)
+
+	for _, coauthor := range coauthors {
+		if coauthor == "none" {
+			return ""
+		}
+		fmt.Fprintf(&s, "\nCo-authored-by: %s", coauthor)
+	}
+	return s.String()
 }

--- a/pkg/config/co_author_test.go
+++ b/pkg/config/co_author_test.go
@@ -1,0 +1,81 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stefanlogue/meteor/pkg/config"
+)
+
+func TestBuildCoAuthorString(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		coauthors []string
+		want      string
+	}{
+		{
+			name:      "empty slice returns empty string",
+			coauthors: []string{},
+			want:      "\n\n\n\t",
+		},
+		{
+			name:      "none option returns empty string",
+			coauthors: []string{"none"},
+			want:      "",
+		},
+		{
+			name:      "single coauthor",
+			coauthors: []string{"John Doe <john@example.com>"},
+			want:      "\n\n\n\t\nCo-authored-by: John Doe <john@example.com>",
+		},
+		{
+			name: "multiple coauthors",
+			coauthors: []string{
+				"John Doe <john@example.com>",
+				"Jane Smith <jane@example.com>",
+			},
+			want: "\n\n\n\t\nCo-authored-by: John Doe <john@example.com>\nCo-authored-by: Jane Smith <jane@example.com>",
+		},
+		{
+			name: "none in middle of list",
+			coauthors: []string{
+				"John Doe <john@example.com>",
+				"none",
+				"Jane Smith <jane@example.com>",
+			},
+			want: "",
+		},
+		{
+			name: "multiple coauthors with different formats",
+			coauthors: []string{
+				"John Doe <john@example.com>",
+				"Jane Smith <jane@example.com>",
+				"Bob Johnson <bob@example.com>",
+			},
+			want: "\n\n\n\t\nCo-authored-by: John Doe <john@example.com>\nCo-authored-by: Jane Smith <jane@example.com>\nCo-authored-by: Bob Johnson <bob@example.com>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.BuildCoAuthorString(tt.coauthors)
+			if got != tt.want {
+				t.Errorf("BuildCoAuthorString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildCoauthorString_NoneShortCircuits(t *testing.T) {
+	// Verify that "none" immediately returns empty string
+	// even if there are other coauthors after it
+	coauthors := []string{
+		"John Doe <john@example.com>",
+		"none",
+		"This should not appear <test@example.com>",
+	}
+
+	got := config.BuildCoAuthorString(coauthors)
+	if got != "" {
+		t.Errorf("buildCoauthorString() with 'none' = %q, want empty string", got)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,8 @@ type Config struct {
 	Boards                    Boards    `json:"boards"`
 	Scopes                    Scopes    `json:"scopes"`
 	ReadContributorsFromGit   *bool     `json:"readContributorsFromGit"`
+	AllowCustomPrefixes       *bool     `json:"allowCustomPrefixes"`
+	AllowCustomScopes         *bool     `json:"allowCustomScopes"`
 }
 
 // New returns a new Config

--- a/pkg/config/prefix.go
+++ b/pkg/config/prefix.go
@@ -13,7 +13,21 @@ type Prefix struct {
 
 type Prefixes []Prefix
 
-var DefaultPrefixes = []huh.Option[string]{
+var DefaultPrefixes = []string{
+	"feat",
+	"fix",
+	"build",
+	"chore",
+	"ci",
+	"docs",
+	"perf",
+	"refactor",
+	"revert",
+	"style",
+	"test",
+}
+
+var DefaultSelectablePrefixes = []huh.Option[string]{
 	huh.NewOption("feat - a new feature", "feat"),
 	huh.NewOption("fix - a bug fix", "fix"),
 	huh.NewOption("build - changes that affect the build system or external dependencies", "build"),
@@ -31,12 +45,25 @@ func (p *Prefixes) Options() []huh.Option[string] {
 	prefixes := []Prefix(*p)
 
 	if len(prefixes) == 0 {
-		return DefaultPrefixes
+		return DefaultSelectablePrefixes
 	}
 	var items []huh.Option[string]
 	for _, prefix := range prefixes {
 		desc := fmt.Sprintf("%s - %s", prefix.T, prefix.D)
 		items = append(items, huh.NewOption(desc, prefix.T))
+	}
+	return items
+}
+
+func (p *Prefixes) Strings() []string {
+	prefixes := []Prefix(*p)
+
+	if len(prefixes) == 0 {
+		return DefaultPrefixes
+	}
+	var items []string
+	for _, prefix := range prefixes {
+		items = append(items, prefix.T)
 	}
 	return items
 }

--- a/pkg/config/prefix_test.go
+++ b/pkg/config/prefix_test.go
@@ -1,0 +1,186 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestPrefixes_Options(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefixes Prefixes
+		want     int
+		wantType string
+	}{
+		{
+			name:     "empty prefixes returns defaults",
+			prefixes: Prefixes{},
+			want:     len(DefaultSelectablePrefixes),
+			wantType: "feat",
+		},
+		{
+			name:     "nil prefixes returns defaults",
+			prefixes: nil,
+			want:     len(DefaultSelectablePrefixes),
+			wantType: "feat",
+		},
+		{
+			name: "custom prefixes returns custom options",
+			prefixes: Prefixes{
+				{T: "custom", D: "a custom prefix"},
+			},
+			want:     1,
+			wantType: "custom",
+		},
+		{
+			name: "multiple custom prefixes",
+			prefixes: Prefixes{
+				{T: "feature", D: "a new feature"},
+				{T: "bugfix", D: "a bug fix"},
+				{T: "hotfix", D: "a critical fix"},
+			},
+			want:     3,
+			wantType: "feature",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.prefixes.Options()
+
+			if len(got) != tt.want {
+				t.Errorf("Options() returned %d items, want %d", len(got), tt.want)
+			}
+
+			if len(got) > 0 {
+				// Check that the first option has the expected value
+				firstValue := got[0].Value
+				if firstValue != tt.wantType {
+					t.Errorf("Options() first value = %v, want %v", firstValue, tt.wantType)
+				}
+			}
+		})
+	}
+}
+
+func TestPrefixes_Options_Format(t *testing.T) {
+	prefixes := Prefixes{
+		{T: "feat", D: "a new feature"},
+	}
+
+	got := prefixes.Options()
+
+	if len(got) != 1 {
+		t.Fatalf("Options() returned %d items, want 1", len(got))
+	}
+
+	// Verify the option format matches "type - description"
+	expectedKey := "feat - a new feature"
+	expectedValue := "feat"
+
+	if got[0].Key != expectedKey {
+		t.Errorf("Options() key = %q, want %q", got[0].Key, expectedKey)
+	}
+
+	if got[0].Value != expectedValue {
+		t.Errorf("Options() value = %q, want %q", got[0].Value, expectedValue)
+	}
+}
+
+func TestPrefixes_Strings(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefixes Prefixes
+		want     []string
+	}{
+		{
+			name:     "empty prefixes returns defaults",
+			prefixes: Prefixes{},
+			want:     DefaultPrefixes,
+		},
+		{
+			name:     "nil prefixes returns defaults",
+			prefixes: nil,
+			want:     DefaultPrefixes,
+		},
+		{
+			name: "custom prefixes returns custom strings",
+			prefixes: Prefixes{
+				{T: "custom", D: "a custom prefix"},
+			},
+			want: []string{"custom"},
+		},
+		{
+			name: "multiple custom prefixes",
+			prefixes: Prefixes{
+				{T: "feature", D: "a new feature"},
+				{T: "bugfix", D: "a bug fix"},
+				{T: "hotfix", D: "a critical fix"},
+			},
+			want: []string{"feature", "bugfix", "hotfix"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.prefixes.Strings()
+
+			if len(got) != len(tt.want) {
+				t.Errorf("Strings() returned %d items, want %d", len(got), len(tt.want))
+				return
+			}
+
+			for i, v := range got {
+				if v != tt.want[i] {
+					t.Errorf("Strings()[%d] = %v, want %v", i, v, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestPrefixes_Strings_IgnoresDescriptions(t *testing.T) {
+	prefixes := Prefixes{
+		{T: "feat", D: "description 1"},
+		{T: "fix", D: "description 2"},
+	}
+
+	got := prefixes.Strings()
+	want := []string{"feat", "fix"}
+
+	if len(got) != len(want) {
+		t.Fatalf("Strings() returned %d items, want %d", len(got), len(want))
+	}
+
+	for i, v := range got {
+		if v != want[i] {
+			t.Errorf("Strings()[%d] = %v, want %v", i, v, want[i])
+		}
+	}
+}
+
+func TestDefaultPrefixes_Length(t *testing.T) {
+	if len(DefaultPrefixes) != 11 {
+		t.Errorf("DefaultPrefixes length = %d, want 11", len(DefaultPrefixes))
+	}
+}
+
+func TestDefaultSelectablePrefixes_Length(t *testing.T) {
+	if len(DefaultSelectablePrefixes) != 11 {
+		t.Errorf("DefaultSelectablePrefixes length = %d, want 11", len(DefaultSelectablePrefixes))
+	}
+}
+
+func TestDefaultPrefixes_MatchesSelectablePrefixes(t *testing.T) {
+	if len(DefaultPrefixes) != len(DefaultSelectablePrefixes) {
+		t.Errorf("DefaultPrefixes and DefaultSelectablePrefixes have different lengths: %d vs %d",
+			len(DefaultPrefixes), len(DefaultSelectablePrefixes))
+	}
+
+	// Verify each default prefix has a corresponding selectable option
+	for i, prefix := range DefaultPrefixes {
+		if DefaultSelectablePrefixes[i].Value != prefix {
+			t.Errorf("DefaultSelectablePrefixes[%d].Value = %q, want %q",
+				i, DefaultSelectablePrefixes[i].Value, prefix)
+		}
+	}
+}

--- a/pkg/config/scope.go
+++ b/pkg/config/scope.go
@@ -22,3 +22,16 @@ func (s *Scopes) Options() []huh.Option[string] {
 	items[0] = huh.NewOption("none", "")
 	return items
 }
+
+func (s *Scopes) Strings() []string {
+	scopes := []Scope(*s)
+
+	if len(scopes) == 0 {
+		return nil
+	}
+	var items []string
+	for _, scope := range scopes {
+		items = append(items, scope.Name)
+	}
+	return items
+}

--- a/pkg/config/scope_test.go
+++ b/pkg/config/scope_test.go
@@ -1,0 +1,215 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestScopes_Options(t *testing.T) {
+	tests := []struct {
+		name       string
+		scopes     Scopes
+		wantLen    int
+		wantNil    bool
+		wantFirst  string
+		wantSecond string
+	}{
+		{
+			name:    "empty scopes returns nil",
+			scopes:  Scopes{},
+			wantNil: true,
+		},
+		{
+			name:    "nil scopes returns nil",
+			scopes:  nil,
+			wantNil: true,
+		},
+		{
+			name: "single scope returns none + scope",
+			scopes: Scopes{
+				{Name: "api"},
+			},
+			wantLen:    2,
+			wantFirst:  "", // "none" option has empty value
+			wantSecond: "api",
+		},
+		{
+			name: "multiple scopes returns none + all scopes",
+			scopes: Scopes{
+				{Name: "api"},
+				{Name: "ui"},
+				{Name: "db"},
+			},
+			wantLen:    4,
+			wantFirst:  "",
+			wantSecond: "api",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.scopes.Options()
+
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("Options() = %v, want nil", got)
+				}
+				return
+			}
+
+			if len(got) != tt.wantLen {
+				t.Errorf("Options() returned %d items, want %d", len(got), tt.wantLen)
+				return
+			}
+
+			// Check first option is "none" with empty value
+			if got[0].Value != tt.wantFirst {
+				t.Errorf("Options()[0].Value = %q, want %q", got[0].Value, tt.wantFirst)
+			}
+
+			if got[0].Key != "none" {
+				t.Errorf("Options()[0].Key = %q, want %q", got[0].Key, "none")
+			}
+
+			// Check second option if exists
+			if len(got) > 1 && got[1].Value != tt.wantSecond {
+				t.Errorf("Options()[1].Value = %q, want %q", got[1].Value, tt.wantSecond)
+			}
+		})
+	}
+}
+
+func TestScopes_Options_OrderPreserved(t *testing.T) {
+	scopes := Scopes{
+		{Name: "frontend"},
+		{Name: "backend"},
+		{Name: "database"},
+	}
+
+	got := scopes.Options()
+
+	if len(got) != 4 {
+		t.Fatalf("Options() returned %d items, want 4", len(got))
+	}
+
+	expectedOrder := []string{"", "frontend", "backend", "database"}
+	for i, expected := range expectedOrder {
+		if got[i].Value != expected {
+			t.Errorf("Options()[%d].Value = %q, want %q", i, got[i].Value, expected)
+		}
+	}
+
+	// Verify "none" is first
+	if got[0].Key != "none" {
+		t.Errorf("Options()[0].Key = %q, want %q", got[0].Key, "none")
+	}
+
+	// Verify other keys match their values
+	for i := 1; i < len(got); i++ {
+		if got[i].Key != got[i].Value {
+			t.Errorf("Options()[%d].Key = %q, want %q", i, got[i].Key, got[i].Value)
+		}
+	}
+}
+
+func TestScopes_Strings(t *testing.T) {
+	tests := []struct {
+		name    string
+		scopes  Scopes
+		want    []string
+		wantNil bool
+	}{
+		{
+			name:    "empty scopes returns nil",
+			scopes:  Scopes{},
+			wantNil: true,
+		},
+		{
+			name:    "nil scopes returns nil",
+			scopes:  nil,
+			wantNil: true,
+		},
+		{
+			name: "single scope returns single string",
+			scopes: Scopes{
+				{Name: "api"},
+			},
+			want: []string{"api"},
+		},
+		{
+			name: "multiple scopes returns all strings",
+			scopes: Scopes{
+				{Name: "api"},
+				{Name: "ui"},
+				{Name: "db"},
+			},
+			want: []string{"api", "ui", "db"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.scopes.Strings()
+
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("Strings() = %v, want nil", got)
+				}
+				return
+			}
+
+			if len(got) != len(tt.want) {
+				t.Errorf("Strings() returned %d items, want %d", len(got), len(tt.want))
+				return
+			}
+
+			for i, v := range got {
+				if v != tt.want[i] {
+					t.Errorf("Strings()[%d] = %v, want %v", i, v, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestScopes_Strings_NoNoneOption(t *testing.T) {
+	scopes := Scopes{
+		{Name: "api"},
+		{Name: "ui"},
+	}
+
+	got := scopes.Strings()
+
+	// Verify "none" is NOT included in Strings() output
+	for i, v := range got {
+		if v == "" || v == "none" {
+			t.Errorf("Strings()[%d] = %q, should not contain empty or 'none'", i, v)
+		}
+	}
+
+	// Verify we only have the actual scope names
+	want := []string{"api", "ui"}
+	if len(got) != len(want) {
+		t.Errorf("Strings() length = %d, want %d", len(got), len(want))
+	}
+}
+
+func TestScopes_Strings_OrderPreserved(t *testing.T) {
+	scopes := Scopes{
+		{Name: "zulu"},
+		{Name: "alpha"},
+		{Name: "bravo"},
+	}
+
+	got := scopes.Strings()
+	want := []string{"zulu", "alpha", "bravo"}
+
+	if len(got) != len(want) {
+		t.Fatalf("Strings() returned %d items, want %d", len(got), len(want))
+	}
+
+	for i, v := range got {
+		if v != want[i] {
+			t.Errorf("Strings()[%d] = %q, want %q (order should be preserved)", i, v, want[i])
+		}
+	}
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,6 +10,7 @@ sonar.exclusions=**/*_test.go,*.yml
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
 sonar.test.exclusions=*.yml
+sonar.coverage.exclusions=main.go
 sonar.go.coverage.reportPaths=cov.out
 
 sonar.externalIssuesReportPaths=report.json


### PR DESCRIPTION
This pull request introduces enhanced flexibility for commit type and scope selection by allowing custom prefixes and scopes, as well as improving how default and selectable options are handled. The main changes include new configuration flags, refactoring of prefix and scope handling, and updates to the user input logic to support suggestions and custom entries.

Closes #91 

**Configuration and Defaults:**
- Added `AllowCustomPrefixes` and `AllowCustomScopes` boolean fields to the configuration (`Config` struct and `LoadConfigReturn`), allowing users to enable custom commit types and scopes. [[1]](diffhunk://#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5R25-R26) [[2]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L26-R38)
- Split default prefixes into two lists: `DefaultPrefixes` (simple strings for suggestions and custom input) and `DefaultSelectablePrefixes` (for select menu options), providing more flexibility.

**Prefix and Scope Handling:**
- Added `Strings()` methods to both `Prefixes` and `Scopes` types to easily retrieve string slices for use in suggestions and custom input fields. [[1]](diffhunk://#diff-08d79e570cfa986419c3a5f322466258831a05a464071964a7f3292d3b6f53e5R57-R69) [[2]](diffhunk://#diff-eea7768c2276d359e488f71d39ea07cb7b85926048246a1fdbc2f79541d6f9f0R25-R37)
- Refactored the `Options()` methods to use the new selectable defaults where appropriate.

**User Input Logic:**
- Updated the main input flow to use a text input with suggestions if custom prefixes or scopes are allowed, otherwise defaulting to select menus. This provides a more user-friendly and configurable experience.

**Configuration Loading:**
- Ensured that the new configuration flags default to `false` if not set, maintaining backward compatibility.
- Updated the `loadConfig` function to populate all new fields and handle both string and option lists for prefixes and scopes. [[1]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R49-R56) [[2]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249L119-R148)