### PR TITLE
Fix to use `spf13/pflag` instead of `flag`

### DIFF
--- a/internal/util/isFlagPassed.go
+++ b/internal/util/isFlagPassed.go
@@ -1,6 +1,6 @@
 package util
 
-import "flag"
+import flag "github.com/spf13/pflag"
 
 func IsFlagPassed(name string) bool {
 	found := false

--- a/internal/util/isFlagPassed_test.go
+++ b/internal/util/isFlagPassed_test.go
@@ -3,19 +3,32 @@ package util_test
 import (
 	"testing"
 
+	flag "github.com/spf13/pflag"
 	"github.com/stefanlogue/meteor/internal/util"
 )
 
 func TestIsFlagPassed(t *testing.T) {
+	original := flag.CommandLine
+	t.Cleanup(func() {
+		flag.CommandLine = original
+	})
+
 	tests := []struct {
 		name     string
 		flagName string
+		setFlag  bool
 		want     bool
 	}{
 		{
+			name:     "version flag is not passed",
+			flagName: "version",
+			want:     false,
+		},
+		{
 			name:     "version flag is passed",
 			flagName: "version",
-			want:     false, // Will be false in test context unless explicitly set
+			setFlag:  true,
+			want:     true,
 		},
 		{
 			name:     "non-existent flag",
@@ -25,6 +38,14 @@ func TestIsFlagPassed(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+			flag.Bool("version", false, "")
+			if tt.setFlag {
+				if err := flag.CommandLine.Set(tt.flagName, "true"); err != nil {
+					t.Fatalf("failed setting flag %q: %v", tt.flagName, err)
+				}
+			}
+
 			got := util.IsFlagPassed(tt.flagName)
 			if got != tt.want {
 				t.Errorf("IsFlagPassed() = %v, want %v", got, tt.want)


### PR DESCRIPTION
The official flag package were used in a util package accidentally on refactoring.

fix: #93